### PR TITLE
Fix build error

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -37,9 +37,11 @@
 
 #include <stdlib.h>
 #include <string.h>
-
-#include "parser.h"
 %}
+
+%top {
+#include "parser.h"
+}
 
 %option outfile="lexer.c" header-file="lexer.h"
 %option noyywrap nounput noinput reentrant bison-bridge bison-locations yylineno


### PR DESCRIPTION
Fix of order of inclusion of files. Type YYSTYPE is used before inclusion
of parser.h. This leads to the following error:

```
In file included from kafel.c:28:0:
lexer.h:301:1: error: unknown type name 'YYSTYPE'
 YYSTYPE * kafel_yyget_lval (yyscan_t yyscanner );
 ^~~~~~~
lexer.h:303:24: error: unknown type name 'YYSTYPE'
```

The error occurs when building with:
```
$ flex --version
flex 2.6.0

$ bison --version |grep ^bison
bison (GNU Bison) 3.0.4.0.14.8bf2
```