### PR TITLE
Fix 6 dependency issues in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -81,9 +81,9 @@ lexer.o: parser.h context.h includes.h policy.h expression.h syscall.h
 lexer.o: common.h
 parser.o: parser.h context.h includes.h policy.h expression.h syscall.h
 parser.o: lexer.h
-syscalls/amd64_syscalls.o: syscall.h
-syscalls/i386_syscalls.o: syscall.h
-syscalls/aarch64_syscalls.o: syscall.h
-syscalls/mipso32_syscalls.o: syscall.h
-syscalls/mips64_syscalls.o: syscall.h
-syscalls/arm_syscalls.o: syscall.h
+syscalls/amd64_syscalls.o: syscall.h syscalls/amd64_syscalls.c 
+syscalls/i386_syscalls.o: syscall.h syscalls/i386_syscalls.c
+syscalls/aarch64_syscalls.o: syscall.h syscalls/aarch64_syscalls.c
+syscalls/mipso32_syscalls.o: syscall.h syscalls/mipso32_syscalls.c
+syscalls/mips64_syscalls.o: syscall.h syscalls/mips64_syscalls.c
+syscalls/arm_syscalls.o: syscall.h syscalls/arm_syscalls.c


### PR DESCRIPTION
Hi, I've fixed 6 missing dependencies reported.
Those issues can cause incorrect results when kafel is incrementally built.
For example, any changes in "syscalls/amd64_syscalls.c" will not cause "syscalls/amd64_syscalls.o" to be rebuilt, which is incorrect. 
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake