### PR TITLE
Fix build with bison >= 3.7.5

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -420,8 +420,8 @@ const_def
 
 void yyerror(YYLTYPE * loc, struct kafel_ctxt* ctxt, yyscan_t scanner,
              const char *msg) {
+  (void)scanner; /* suppress unused-parameter warning */
   if (!ctxt->lexical_error) {
-    YYUSE(scanner);
     if (loc->filename != NULL) {
       append_error(ctxt, "%s:%d:%d: %s", loc->filename, loc->first_line, loc->first_column, msg);
     } else {


### PR DESCRIPTION
Fixes the following linker error:

```
/usr/bin/ld: kafel/libkafel.a(libkafel.o): in function `kafel_yyerror':
arm_syscalls.c:(.text+0x6984): undefined reference to `YYUSE'
```