### PR TITLE
Fix riscv64 judgment

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -51,7 +51,7 @@
 #define KAFEL_DEFAULT_TARGET_ARCH AUDIT_ARCH_MIPS
 #elif defined(__i386__)
 #define KAFEL_DEFAULT_TARGET_ARCH AUDIT_ARCH_I386
-#elif defined(__riscv) &&  __riscv_len == 64
+#elif defined(__riscv) && __riscv_len == 64
 #define KAFEL_DEFAULT_TARGET_ARCH AUDIT_ARCH_RISCV64
 #else
 #error "Unsupported architecture"


### PR DESCRIPTION
The old judgment was able to determine that the architecture was RISCV, but not completely sure that it was riscv64.
So this commit fixes that problem.