### PR TITLE
Add special rules for generated headers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -65,11 +65,19 @@ ${STATIC_TARGET}: ${OBJECTS}
 	$(AR) rcs $@ libkafel.o
 	$(RM) libkafel.o
 
-lexer.h lexer.c: lexer.l
+lexer.c: lexer.l
 	flex $<
 
-parser.h parser.c: parser.y
+lexer.h: lexer.c
+	@if test ! -f lexer.h; then rm -f lexer.c; fi
+	@if test ! -f lexer.h; then $(MAKE) lexer.c; fi
+
+parser.c: parser.y
 	bison $<
+
+parser.h: parser.c
+	@if test ! -f parser.h; then rm -f parser.c; fi
+	@if test ! -f parser.h; then $(MAKE) parser.c; fi
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 


### PR DESCRIPTION
bison(1) and flex(1) pose a problem for make(1) because they generate many output files. These files when properly added to dependency tree may make make(1) run rules to generate them twice depending on timing which in turn results in a race condition and failed build especially on heavily loaded systems.

To aviod that special rules that serialise dependencies need to be introduced which is what automake(1) has made for long time.

https://git.savannah.gnu.org/cgit/automake.git/commit/?id=788a63b300568b1c1876e4ad30b966df2f0710fc

Additionally to avoid problems when running `make -n`, rm(1) and make(1) commands need to be placed under separate `if` statements.

https://git.savannah.gnu.org/cgit/automake.git/commit/?id=d7c1679b14c1ab691927f3243df1cb3cbb2360aa