### PR TITLE
fix: canonicalize include paths to prevent directory traversal (CWE-22)

### DIFF
--- a/src/includes.c
+++ b/src/includes.c
@@ -110,17 +110,47 @@ struct included_file* includes_resolve(struct includes_ctxt* ctxt,
   struct path_list* search_path;
   TAILQ_FOREACH(search_path, &ctxt->search_paths, list) {
     char* path = path_join(search_path->path, filename);
-    FILE* fp = fopen(path, "r");
+
+    /* Canonicalize to resolve any ../ sequences before opening. */
+    char* canonical = realpath(path, NULL);
+    free(path);
+    if (canonical == NULL) {
+      /* File does not exist in this search path or realpath failed. */
+      continue;
+    }
+
+    /* Canonicalize the search path for a safe prefix comparison. */
+    char* canonical_search = realpath(search_path->path, NULL);
+    if (canonical_search == NULL) {
+      free(canonical);
+      continue;
+    }
+
+    /* Verify the resolved path stays within the search directory.
+     * The next character after the prefix must be '/' or '\0' to
+     * prevent /foo/bar from matching /foo/barbaz. */
+    size_t search_len = strlen(canonical_search);
+    bool within = (strncmp(canonical, canonical_search, search_len) == 0 &&
+                   (canonical[search_len] == '/' ||
+                    canonical[search_len] == '\0'));
+    free(canonical_search);
+
+    if (!within) {
+      free(canonical);
+      continue;
+    }
+
+    FILE* fp = fopen(canonical, "r");
     if (fp != NULL) {
       struct path_list* used_path = calloc(1, sizeof(*used_path));
-      used_path->path = path;
+      used_path->path = canonical;  /* ownership transferred to used_paths list */
       TAILQ_INSERT_TAIL(&ctxt->used_paths, used_path, list);
       struct included_file* file = calloc(1, sizeof(*file));
       file->fp = fp;
       file->path = used_path->path;
       return file;
     }
-    free(path);
+    free(canonical);
   }
   return NULL;
 }


### PR DESCRIPTION
## Bug
  includes_resolve() in src/includes.c passes the raw output of
  path_join() directly to fopen() without validating that the
  resulting path stays within the intended search directory.
  path_join() is a simple string concatenation — it does not strip or
  resolve ../ sequences. An attacker who controls the content of a
  kafel policy file can embed a path traversal sequence in an #include
  directive to open arbitrary files readable by the process.
  ## Reproduction
  Given a search path /var/lib/policies and a policy file containing:
  #include "../../../etc/shadow"
  path_join() produces /var/lib/policies/../../../etc/shadow. The OS
  resolves this to /etc/shadow at fopen() time. If the file is
  readable by the process, the lexer opens and begins parsing it. While
  the content is not echoed back verbatim, the attack enables:
  - **Filesystem probing** — distinguishing "file not found" from a parse
    error confirms whether arbitrary paths exist.
  - **Partial content disclosure** — parse error messages include the
    first unexpected token and its line/column, leaking content fragments.
  - **Denial of service** — including /dev/urandom or a named pipe
    causes the lexer to block or spin.
  - **Symlink traversal** — a symlink inside the search directory that
    points outside it is also accepted by the unpatched code.
  The MAX_INCLUDE_DEPTH guard (16 levels) does not mitigate this; it
  only prevents unbounded recursion.
  **Affected versions:** all versions since include support was added
  (commit 8724cf5, Sep 2018).
  ## Fix
  After path_join(), call realpath(path, NULL) to obtain the
  canonical absolute path with all ../, ./, and symlink components
  resolved. Then call realpath() on the search directory itself and
  verify the canonical file path has the canonical search path as a
  proper prefix (guarding the boundary with a / or \0 check to
  prevent /foo/bar from matching /foo/barbaz). Reject the include
  and continue to the next search path if the check fails.
  If realpath() returns NULL (file does not exist, or a path
  component is inaccessible), the search path is skipped — identical
  behavior to a failed fopen() in the original code.
  The realpath() return value is malloc-allocated; ownership is
  transferred to the used_paths list, which includes_ctxt_clean()
  already frees, so there is no change to memory ownership semantics.
  ## Changed files
  - src/includes.c — includes_resolve() only. No API changes, no
    struct changes, no new dependencies (realpath is POSIX.1-2008;
    stdlib.h and string.h were already included).
  ## Security impact
  Exploitability requires an attacker to control the content of a policy
  file passed to kafel_compile() or kafel_compile_file(). The typical
  deployment (policy authored by the application developer at build time)
  is not directly affected. However, any application that compiles
  user-supplied or externally-fetched kafel policies — including
  policy-as-a-service tools, container runtimes, or test harnesses — is
  at risk.